### PR TITLE
Fix text Ebooks-Resource

### DIFF
--- a/linkit-project-client/src/components/Paneles/AdminProfile/Panel/AdminRecursos/FormResource.tsx
+++ b/linkit-project-client/src/components/Paneles/AdminProfile/Panel/AdminRecursos/FormResource.tsx
@@ -302,8 +302,8 @@ export default function FormResource({
                       type="text"
                       name="image"
                       placeholder={
-                        information.type === "ebook" ? "Imagen" : "Imagen cargada"
-                      }
+                        filePublicId.length > 0 ? "Imagen cargada": "Cargar imagen"
+                      } 
                       autoComplete="off"
                       onChange={handleChange}
                       disabled


### PR DESCRIPTION
" The text for 'Image' was changed to 'Upload Image,' and once the upload is completed, it changes to 'Image Uploaded' in ebooks resources feature."